### PR TITLE
Pass ...Expr_ConstFetch a ...Node_Name if isDefaultValueConstant is true

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,11 @@
             "CodeGenerationUtils\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-0": {
+            "CodeGenerationUtilsTests\\": "tests"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/src/CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php
+++ b/src/CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php
@@ -206,7 +206,9 @@ class ClassBuilder extends PHPParser_BuilderAbstract
                 && $reflectionParameter->isDefaultValueConstant()
             ) {
                 $parameterBuilder->setDefault(
-                    new PHPParser_Node_Expr_ConstFetch($reflectionParameter->getDefaultValueConstantName())
+                    new PHPParser_Node_Expr_ConstFetch(
+                        new PHPParser_Node_Name($reflectionParameter->getDefaultValueConstantName())
+                    )
                 );
             } else {
                 $parameterBuilder->setDefault($reflectionParameter->getDefaultValue());

--- a/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
+++ b/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
@@ -19,6 +19,7 @@
 namespace CodeGenerationUtilsTest\Visitor;
 
 use CodeGenerationUtils\ReflectionBuilder\ClassBuilder;
+use CodeGenerationUtilsTest\ReflectionBuilder\ClassWithDefaultValueIsConstantMethod;
 use PHPParser_Node_Stmt_ClassMethod;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
@@ -67,5 +68,35 @@ class ClassBuilderTest extends PHPUnit_Framework_TestCase
         $thisMethod = reset($methods);
 
         $this->assertSame($currentMethod, $thisMethod->name);
+    }
+
+    /**
+     * Check the isDefaultValueConstant edge case.
+     */
+    public function testBuildWithDefaultValueConstantParameter()
+    {
+        $classBuilder = new ClassBuilder();
+        $testClass    = new ClassWithDefaultValueIsConstantMethod();
+        $ast          = $classBuilder->fromReflection(new ReflectionClass($testClass));
+
+        /* @var $namespace \PHPParser_Node_Stmt_Namespace */
+        $namespace = $ast[0];
+        $class     = $namespace->stmts[0];
+        $method    = 'defaultValueIsConstant';
+
+        /* @var $methods PHPParser_Node_Stmt_ClassMethod[] */
+        $methods = array_filter(
+            $class->stmts,
+            function ($node) use ($method) {
+                return ($node instanceof PHPParser_Node_Stmt_ClassMethod && $node->name === $method);
+            }
+        );
+
+        $this->assertCount(1, $methods);
+
+        /* @var $thisMethod PHPParser_Node_Stmt_ClassMethod */
+        $thisMethod = reset($methods);
+
+        $this->assertSame($method, $thisMethod->name);
     }
 }

--- a/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassWithDefaultValueIsConstantMethod.php
+++ b/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassWithDefaultValueIsConstantMethod.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace CodeGenerationUtilsTest\ReflectionBuilder;
+
+/**
+ * Class to use for testing the ReflectionBuilder {@see \CodeGenerationUtilsTest\Visitor\ClassBuilderTest}
+ *
+ * @author Samuel Parkinson <sam@graze.com>
+ * @license MIT
+ */
+class ClassWithDefaultValueIsConstantMethod
+{
+    /**
+     * Method to test the ReflectionProperty::getDefaultValueConstantName usage
+     * within {@see \CodeGenerationUtils\ReflectionBuilder\ClassBuilder}.
+     *
+     * @param string $test
+     * @return void
+     */
+    public function defaultValueIsConstant($test = PHP_VERSION)
+    {
+        return;
+    }
+}


### PR DESCRIPTION
<img src="http://media.giphy.com/media/11bnQmUcjLzy00/giphy.gif" align="right" />

Currently PHPParser_Node_Expr_ConstFetch is [being passed a string](https://github.com/Ocramius/CodeGenerationUtils/blob/0.1.0/src/CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php#L208-L210) by [ReflectionParameter::getDefaultValueConstantName](http://php.net/manual/en/reflectionparameter.getdefaultvalueconstantname.php) when the constructor actually expects a PHPParser_Node_Name as the first argument.

I've added a test to cover the code, happy to change the way I've implemented the test, couldn't work out how to cleanly pass ReflectionClass a class that has a method with the right arguments.

The error this resolves:

> Argument 1 passed to PHPParser_Node_Expr_ConstFetch::__construct() must be an instance of PHPParser_Node_Name, string given, called in CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php on line 209
