### PR TITLE
Update ParameterEncoder.php

### DIFF
--- a/src/CodeGenerationUtils/Inflector/Util/ParameterEncoder.php
+++ b/src/CodeGenerationUtils/Inflector/Util/ParameterEncoder.php
@@ -36,6 +36,6 @@ class ParameterEncoder
      */
     public function encodeParameters(array $parameters)
     {
-        return strtr(base64_encode(serialize($parameters)), '+/=', '†‡•');
+        return 'C' . hash('sha256', serialize($parameters));
     }
 }


### PR DESCRIPTION
There are some problems with the original implementation
1. when $parameters is big the filename gets too long for the OS
2. base64_encode can generate a string that starts as a number. But this function is used to generate class names, and classes may not start with a number
3. uses characters which are not present on the keyboard `†‡•`

sha256 should generate a string long enough to avoid collision
prefixed `C` to have it start with a letter (i choose `C` because of Class)
