### PR TITLE
remove phpunit deprecation notices by using createMock()

### DIFF
--- a/tests/CodeGenerationUtilsTest/Autoloader/AutoloaderTest.php
+++ b/tests/CodeGenerationUtilsTest/Autoloader/AutoloaderTest.php
@@ -52,8 +52,8 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->fileLocator        = $this->getMock('CodeGenerationUtils\\FileLocator\\FileLocatorInterface');
-        $this->classNameInflector = $this->getMock('CodeGenerationUtils\\Inflector\\ClassNameInflectorInterface');
+        $this->fileLocator        = $this->createMock('CodeGenerationUtils\\FileLocator\\FileLocatorInterface');
+        $this->classNameInflector = $this->createMock('CodeGenerationUtils\\Inflector\\ClassNameInflectorInterface');
         $this->autoloader         = new Autoloader($this->fileLocator, $this->classNameInflector);
     }
 

--- a/tests/CodeGenerationUtilsTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
+++ b/tests/CodeGenerationUtilsTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
@@ -55,7 +55,7 @@ class BaseGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $strategy = new BaseGeneratorStrategy();
 
         /* @var $prettyPrinter PrettyPrinterAbstract|\PHPUnit_Framework_MockObject_MockObject */
-        $prettyPrinter = $this->getMock(PrettyPrinterAbstract::class);
+        $prettyPrinter = $this->createMock(PrettyPrinterAbstract::class);
 
         $prettyPrinter
             ->expects(self::once())

--- a/tests/CodeGenerationUtilsTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/CodeGenerationUtilsTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -43,7 +43,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
     public function testGenerate()
     {
         /* @var $locator \PHPUnit_Framework_MockObject_MockObject|FileLocatorInterface */
-        $locator   = $this->getMock(FileLocatorInterface::class);
+        $locator   = $this->createMock(FileLocatorInterface::class);
         $generator = new FileWriterGeneratorStrategy($locator);
         $tmpFile   = sys_get_temp_dir() . '/FileWriterGeneratorStrategyTest' . uniqid('', true) . '.php';
         $className = UniqueIdentifierGenerator::getIdentifier('Bar');

--- a/tests/CodeGenerationUtilsTest/Visitor/MethodDisablerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/MethodDisablerVisitorTest.php
@@ -40,7 +40,7 @@ class MethodDisablerVisitorTest extends PHPUnit_Framework_TestCase
     {
         $method = new ClassMethod('test');
         /* @var $filter \PHPUnit_Framework_MockObject_MockObject|callable */
-        $filter = $this->getMock('stdClass', array('__invoke'));
+        $filter = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
 
         $filter->expects(self::once())->method('__invoke')->with($method)->will(self::returnValue(true));
 
@@ -54,7 +54,7 @@ class MethodDisablerVisitorTest extends PHPUnit_Framework_TestCase
     {
         $method = new ClassMethod('test');
         /* @var $filter \PHPUnit_Framework_MockObject_MockObject|callable */
-        $filter = $this->getMock('stdClass', array('__invoke'));
+        $filter = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
 
         $filter->expects(self::once())->method('__invoke')->with($method)->will(self::returnValue(false));
 
@@ -67,7 +67,7 @@ class MethodDisablerVisitorTest extends PHPUnit_Framework_TestCase
     {
         $method = new ClassMethod('test');
         /* @var $filter \PHPUnit_Framework_MockObject_MockObject|callable */
-        $filter = $this->getMock('stdClass', array('__invoke'));
+        $filter = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
 
         $filter->expects(self::once())->method('__invoke')->with($method)->will(self::returnValue(null));
 
@@ -80,7 +80,7 @@ class MethodDisablerVisitorTest extends PHPUnit_Framework_TestCase
     {
         $class  = new Class_('test');
         /* @var $filter \PHPUnit_Framework_MockObject_MockObject|callable */
-        $filter = $this->getMock('stdClass', array('__invoke'));
+        $filter = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
 
         $filter->expects(self::never())->method('__invoke');
 


### PR DESCRIPTION
Hi!,

I think this should remove all the PHPUnit deprecation notices. 