### PR TITLE
chore: allow php parser v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":                       "~7.0",
-        "nikic/php-parser":          "~2.0"
+        "nikic/php-parser":          "~2.0|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit":           "~5.0",


### PR DESCRIPTION
Hi,

Im sorry I don't know enough about this library to really assert this is working correctly. However the unit tests are passing (or the same as v2) .. So maybe its good? 

My main objective is https://github.com/Ocramius/GeneratedHydrator/issues/67

Do you want to support both versions? I will need to edit the travis if so.. 