### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser":          "~2.0|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit":           "^5.7.21",
+        "phpunit/phpunit":           "^6.4",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/tests/CodeGenerationUtilsTest/Autoloader/AutoloaderTest.php
+++ b/tests/CodeGenerationUtilsTest/Autoloader/AutoloaderTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Autoloader;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Autoloader\Autoloader;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 
@@ -30,7 +30,7 @@ use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class AutoloaderTest extends PHPUnit_Framework_TestCase
+class AutoloaderTest extends TestCase
 {
     /**
      * @var \CodeGenerationUtils\Autoloader\Autoloader

--- a/tests/CodeGenerationUtilsTest/Exception/DisabledMethodExceptionTest.php
+++ b/tests/CodeGenerationUtilsTest/Exception/DisabledMethodExceptionTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Exception;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Exception\DisabledMethodException;
 
 /**
@@ -29,7 +29,7 @@ use CodeGenerationUtils\Exception\DisabledMethodException;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class DisabledMethodExceptionTest extends PHPUnit_Framework_TestCase
+class DisabledMethodExceptionTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\Exception\DisabledMethodException::disabledMethod

--- a/tests/CodeGenerationUtilsTest/Exception/InvalidGeneratedClassesDirectoryExceptionTest.php
+++ b/tests/CodeGenerationUtilsTest/Exception/InvalidGeneratedClassesDirectoryExceptionTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Exception;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Exception\InvalidGeneratedClassesDirectoryException;
 
 /**
@@ -29,7 +29,7 @@ use CodeGenerationUtils\Exception\InvalidGeneratedClassesDirectoryException;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class InvalidGeneratedClassesDirectoryExceptionTest extends PHPUnit_Framework_TestCase
+class InvalidGeneratedClassesDirectoryExceptionTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\Exception\InvalidGeneratedClassesDirectoryException

--- a/tests/CodeGenerationUtilsTest/FileLocator/FileLocatorTest.php
+++ b/tests/CodeGenerationUtilsTest/FileLocator/FileLocatorTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\FileLocator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\FileLocator\FileLocator;
 
 /**
@@ -29,7 +29,7 @@ use CodeGenerationUtils\FileLocator\FileLocator;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class FileLocatorTest extends PHPUnit_Framework_TestCase
+class FileLocatorTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\FileLocator\FileLocator::__construct
@@ -54,7 +54,7 @@ class FileLocatorTest extends PHPUnit_Framework_TestCase
      */
     public function testRejectsNonExistingDirectory()
     {
-        $this->setExpectedException('CodeGenerationUtils\\Exception\\InvalidGeneratedClassesDirectoryException');
+        $this->expectException('CodeGenerationUtils\\Exception\\InvalidGeneratedClassesDirectoryException');
         new FileLocator(__DIR__ . '/non-existing');
     }
 }

--- a/tests/CodeGenerationUtilsTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
+++ b/tests/CodeGenerationUtilsTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\GeneratorStrategy\BaseGeneratorStrategy;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\PrettyPrinterAbstract;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\GeneratorStrategy\BaseGeneratorStrategy}
@@ -32,7 +32,7 @@ use PHPUnit_Framework_TestCase;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class BaseGeneratorStrategyTest extends PHPUnit_Framework_TestCase
+class BaseGeneratorStrategyTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\GeneratorStrategy\BaseGeneratorStrategy::generate

--- a/tests/CodeGenerationUtilsTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
+++ b/tests/CodeGenerationUtilsTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
@@ -23,7 +23,7 @@ namespace CodeGenerationUtilsTest\GeneratorStrategy;
 use CodeGenerationUtils\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use PhpParser\Node\Stmt\Class_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\GeneratorStrategy\EvaluatingGeneratorStrategy}
@@ -31,7 +31,7 @@ use PHPUnit_Framework_TestCase;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class EvaluatingGeneratorStrategyTest extends PHPUnit_Framework_TestCase
+class EvaluatingGeneratorStrategyTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\GeneratorStrategy\EvaluatingGeneratorStrategy::generate

--- a/tests/CodeGenerationUtilsTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/CodeGenerationUtilsTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -26,7 +26,7 @@ use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\GeneratorStrategy\FileWriterGeneratorStrategy}
@@ -34,7 +34,7 @@ use PHPUnit_Framework_TestCase;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
+class FileWriterGeneratorStrategyTest extends TestCase
 {
     /**
      * @covers \CodeGenerationUtils\GeneratorStrategy\FileWriterGeneratorStrategy::__construct

--- a/tests/CodeGenerationUtilsTest/Inflector/ClassNameInflectorTest.php
+++ b/tests/CodeGenerationUtilsTest/Inflector/ClassNameInflectorTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Inflector;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Inflector\ClassNameInflector;
 use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
 
@@ -30,7 +30,7 @@ use CodeGenerationUtils\Inflector\ClassNameInflectorInterface;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
+class ClassNameInflectorTest extends TestCase
 {
     /**
      * @dataProvider getClassNames

--- a/tests/CodeGenerationUtilsTest/Inflector/Util/ParameterEncoderTest.php
+++ b/tests/CodeGenerationUtilsTest/Inflector/Util/ParameterEncoderTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Inflector\Util;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Inflector\Util\ParameterEncoder;
 
 /**
@@ -29,7 +29,7 @@ use CodeGenerationUtils\Inflector\Util\ParameterEncoder;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class ParameterEncoderTest extends PHPUnit_Framework_TestCase
+class ParameterEncoderTest extends TestCase
 {
     /**
      * @dataProvider getParameters

--- a/tests/CodeGenerationUtilsTest/Inflector/Util/UniqueIdentifierGeneratorTest.php
+++ b/tests/CodeGenerationUtilsTest/Inflector/Util/UniqueIdentifierGeneratorTest.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace CodeGenerationUtilsTest\Inflector\Util;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
 
 /**
@@ -29,7 +29,7 @@ use CodeGenerationUtils\Inflector\Util\UniqueIdentifierGenerator;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class UniqueIdentifierGeneratorTest extends PHPUnit_Framework_TestCase
+class UniqueIdentifierGeneratorTest extends TestCase
 {
     /**
      * @dataProvider getBaseIdentifierNames

--- a/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
+++ b/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
@@ -23,7 +23,7 @@ namespace CodeGenerationUtilsTest\Visitor;
 use CodeGenerationUtils\ReflectionBuilder\ClassBuilder;
 use CodeGenerationUtilsTestAsset\ClassWithDefaultValueIsConstantMethod;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -34,7 +34,7 @@ use ReflectionClass;
  *
  * @covers \CodeGenerationUtils\ReflectionBuilder\ClassBuilder
  */
-class ClassBuilderTest extends PHPUnit_Framework_TestCase
+class ClassBuilderTest extends TestCase
 {
     /**
      * Simple test reflecting this test class

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassClonerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassClonerVisitorTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 namespace CodeGenerationUtilsTest\Visitor;
 
 use CodeGenerationUtils\Visitor\ClassClonerVisitor;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -32,7 +32,7 @@ use ReflectionClass;
  *
  * @covers \CodeGenerationUtils\Visitor\ClassClonerVisitor
  */
-class ClassClonerVisitorTest extends PHPUnit_Framework_TestCase
+class ClassClonerVisitorTest extends TestCase
 {
     public function testClonesClassIntoEmptyNodeList()
     {

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassExtensionVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassExtensionVisitorTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\Visitor\ClassExtensionVisitor;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\Visitor\ClassClonerVisitor}
@@ -34,7 +34,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @covers \CodeGenerationUtils\Visitor\ClassExtensionVisitor
  */
-class ClassExtensionVisitorTest extends PHPUnit_Framework_TestCase
+class ClassExtensionVisitorTest extends TestCase
 {
     public function testRenamesNodesOnMatchingClass()
     {

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassFQCNResolverVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassFQCNResolverVisitorTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\Visitor\ClassFQCNResolverVisitor;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\Visitor\ClassClonerVisitor}
@@ -34,7 +34,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @covers \CodeGenerationUtils\Visitor\ClassFQCNResolverVisitor
  */
-class ClassFQCNResolverVisitorTest extends PHPUnit_Framework_TestCase
+class ClassFQCNResolverVisitorTest extends TestCase
 {
     /**
      * @var ClassFQCNResolverVisitor
@@ -84,7 +84,7 @@ class ClassFQCNResolverVisitorTest extends PHPUnit_Framework_TestCase
 
         $this->visitor->enterNode($class1);
 
-        $this->setExpectedException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
+        $this->expectException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
 
         $this->visitor->enterNode($class2);
     }
@@ -98,7 +98,7 @@ class ClassFQCNResolverVisitorTest extends PHPUnit_Framework_TestCase
 
         $this->visitor->enterNode($namespace1);
 
-        $this->setExpectedException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
+        $this->expectException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
 
         $this->visitor->enterNode($namespace2);
     }
@@ -107,7 +107,7 @@ class ClassFQCNResolverVisitorTest extends PHPUnit_Framework_TestCase
     {
         self::assertSame('', $this->visitor->getNamespace());
 
-        $this->setExpectedException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
+        $this->expectException('CodeGenerationUtils\Visitor\Exception\UnexpectedValueException');
 
         $this->visitor->getName();
     }

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassImplementorVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassImplementorVisitorTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\Visitor\ClassImplementorVisitor;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\Visitor\ClassClonerVisitor}
@@ -34,7 +34,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @covers \CodeGenerationUtils\Visitor\ClassImplementorVisitor
  */
-class ClassImplementorVisitorTest extends PHPUnit_Framework_TestCase
+class ClassImplementorVisitorTest extends TestCase
 {
     public function testRenamesNodesOnMatchingClass()
     {

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassRenamerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassRenamerVisitorTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\Visitor\ClassRenamerVisitor;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -35,7 +35,7 @@ use ReflectionClass;
  *
  * @covers \CodeGenerationUtils\Visitor\ClassRenamerVisitor
  */
-class ClassRenamerVisitorTest extends PHPUnit_Framework_TestCase
+class ClassRenamerVisitorTest extends TestCase
 {
     public function testRenamesNodesOnMatchingClass()
     {

--- a/tests/CodeGenerationUtilsTest/Visitor/MethodDisablerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/MethodDisablerVisitorTest.php
@@ -24,7 +24,7 @@ use CodeGenerationUtils\Visitor\MethodDisablerVisitor;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\Visitor\ClassClonerVisitor}
@@ -34,7 +34,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @covers \CodeGenerationUtils\Visitor\MethodDisablerVisitor
  */
-class MethodDisablerVisitorTest extends PHPUnit_Framework_TestCase
+class MethodDisablerVisitorTest extends TestCase
 {
     public function testDisablesMethod()
     {

--- a/tests/CodeGenerationUtilsTest/Visitor/PublicMethodsFilterVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/PublicMethodsFilterVisitorTest.php
@@ -25,7 +25,7 @@ use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \CodeGenerationUtils\Visitor\ClassClonerVisitor}
@@ -35,7 +35,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @covers \CodeGenerationUtils\Visitor\PublicMethodsFilterVisitor
  */
-class PublicMethodsFilterVisitorTest extends PHPUnit_Framework_TestCase
+class PublicMethodsFilterVisitorTest extends TestCase
 {
     /**
      * @dataProvider nodeProvider


### PR DESCRIPTION
As we support `PHP 7`, I've updated our suite of tests to `PHPUnit 6`. I just need to change the `setExpectedException` method to `expectException`, because [it was removed](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#removed).