### PR TITLE
Support nikic/php-parser only 4 and drop support for 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":                       "^7.1",
-        "nikic/php-parser":          "~2.0|~3.0"
+        "nikic/php-parser":          "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit":           "^7.1",

--- a/src/CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php
+++ b/src/CodeGenerationUtils/ReflectionBuilder/ClassBuilder.php
@@ -23,7 +23,7 @@ namespace CodeGenerationUtils\ReflectionBuilder;
 use PhpParser\Builder\Method;
 use PhpParser\Builder\Param;
 use PhpParser\Builder\Property;
-use PhpParser\BuilderAbstract;
+use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\ConstFetch;
@@ -45,7 +45,7 @@ use ReflectionProperty;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class ClassBuilder extends BuilderAbstract
+class ClassBuilder
 {
     /**
      * @param \ReflectionClass $reflectionClass
@@ -71,7 +71,7 @@ class ClassBuilder extends BuilderAbstract
 
         foreach ($reflectionClass->getConstants() as $constant => $value) {
             $class->stmts[] = new ClassConst(
-                array(new Const_($constant, $this->normalizeValue($value)))
+                array(new Const_($constant, BuilderHelpers::normalizeValue($value)))
             );
         }
 

--- a/src/CodeGenerationUtils/Visitor/ClassExtensionVisitor.php
+++ b/src/CodeGenerationUtils/Visitor/ClassExtensionVisitor.php
@@ -110,7 +110,7 @@ class ClassExtensionVisitor extends NodeVisitorAbstract
                 ? implode('\\', $this->currentNamespace->name->parts)
                 : '';
 
-            if (trim($namespace . '\\' . $node->name, '\\') === $this->matchedClassFQCN) {
+            if (trim($namespace . '\\' . (string)$node->name, '\\') === $this->matchedClassFQCN) {
                 $node->extends = new FullyQualified($this->newParentClassFQCN);
             }
 

--- a/src/CodeGenerationUtils/Visitor/ClassFQCNResolverVisitor.php
+++ b/src/CodeGenerationUtils/Visitor/ClassFQCNResolverVisitor.php
@@ -94,7 +94,7 @@ class ClassFQCNResolverVisitor extends NodeVisitorAbstract
             throw new UnexpectedValueException('No class discovered');
         }
 
-        return $this->class->name;
+        return (string)$this->class->name;
     }
 
     /**

--- a/src/CodeGenerationUtils/Visitor/ClassImplementorVisitor.php
+++ b/src/CodeGenerationUtils/Visitor/ClassImplementorVisitor.php
@@ -110,7 +110,7 @@ class ClassImplementorVisitor extends NodeVisitorAbstract
                 ? implode('\\', $this->currentNamespace->name->parts)
                 : '';
 
-            if (trim($namespace . '\\' . $node->name, '\\') === $this->matchedClassFQCN) {
+            if (trim($namespace . '\\' . (string)$node->name, '\\') === $this->matchedClassFQCN) {
                 $node->implements = $this->interfaces;
             }
 

--- a/src/CodeGenerationUtils/Visitor/ClassRenamerVisitor.php
+++ b/src/CodeGenerationUtils/Visitor/ClassRenamerVisitor.php
@@ -132,7 +132,7 @@ class ClassRenamerVisitor extends NodeVisitorAbstract
 
         if ($node instanceof Class_
             && $this->namespaceMatches()
-            && ($this->reflectedClass->getShortName() === $node->name)
+            && ($this->reflectedClass->getShortName() === (string)$node->name)
         ) {
             $node->name = $this->newName;
 

--- a/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
+++ b/tests/CodeGenerationUtilsTest/ReflectionBuilder/ClassBuilderTest.php
@@ -53,14 +53,14 @@ class ClassBuilderTest extends TestCase
         $class = $namespace->stmts[0];
 
         self::assertInstanceOf('PhpParser\Node\Stmt\Class_', $class);
-        self::assertSame('ClassBuilderTest', $class->name);
+        self::assertSame('ClassBuilderTest', (string)$class->name);
 
         $currentMethod = __FUNCTION__;
         /* @var $methods \PhpParser\Node\Stmt\ClassMethod[] */
         $methods       = array_filter(
             $class->stmts,
             function ($node) use ($currentMethod) {
-                return $node instanceof ClassMethod && $node->name === $currentMethod;
+                return $node instanceof ClassMethod && (string)$node->name === $currentMethod;
             }
         );
 
@@ -69,7 +69,7 @@ class ClassBuilderTest extends TestCase
         /* @var $thisMethod \PhpParser\Node\Stmt\ClassMethod */
         $thisMethod = reset($methods);
 
-        self::assertSame($currentMethod, $thisMethod->name);
+        self::assertSame($currentMethod, (string)$thisMethod->name);
     }
 
     /**
@@ -91,7 +91,7 @@ class ClassBuilderTest extends TestCase
         $methods = array_filter(
             $class->stmts,
             function ($node) use ($method) {
-                return ($node instanceof ClassMethod && $node->name === $method);
+                return ($node instanceof ClassMethod && (string)$node->name === $method);
             }
         );
 
@@ -100,6 +100,6 @@ class ClassBuilderTest extends TestCase
         /* @var $thisMethod \PhpParser\Node\Stmt\ClassMethod */
         $thisMethod = reset($methods);
 
-        self::assertSame($method, $thisMethod->name);
+        self::assertSame($method, (string)$thisMethod->name);
     }
 }

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassClonerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassClonerVisitorTest.php
@@ -54,7 +54,7 @@ class ClassClonerVisitorTest extends TestCase
         $class = end($node->stmts);
 
         self::assertInstanceOf('PhpParser\Node\Stmt\Class_', $class);
-        self::assertSame('ClassClonerVisitorTest', $class->name);
+        self::assertSame('ClassClonerVisitorTest', (string)$class->name);
     }
 
     public function testClonesClassIntoNonEmptyNodeList()

--- a/tests/CodeGenerationUtilsTest/Visitor/ClassRenamerVisitorTest.php
+++ b/tests/CodeGenerationUtilsTest/Visitor/ClassRenamerVisitorTest.php
@@ -51,7 +51,7 @@ class ClassRenamerVisitorTest extends TestCase
         self::assertSame($class, $visitor->leaveNode($class));
         self::assertSame($namespace, $visitor->leaveNode($namespace));
 
-        self::assertSame('Baz', $class->name);
+        self::assertSame('Baz', (string)$class->name);
         self::assertSame(array('Foo', 'Bar'), $namespace->name->parts);
         self::assertSame(array($class), $namespace->stmts);
     }
@@ -70,7 +70,7 @@ class ClassRenamerVisitorTest extends TestCase
         $visitor->leaveNode($class);
         $visitor->leaveNode($namespace);
 
-        self::assertSame('Wrong', $class->name);
+        self::assertSame('Wrong', (string)$class->name);
         self::assertSame(array('CodeGenerationUtilsTest', 'Visitor'), $namespace->name->parts);
     }
 
@@ -88,7 +88,7 @@ class ClassRenamerVisitorTest extends TestCase
         $visitor->leaveNode($class);
         $visitor->leaveNode($namespace);
 
-        self::assertSame('ClassRenamerVisitorTest', $class->name);
+        self::assertSame('ClassRenamerVisitorTest', (string)$class->name);
         self::assertSame(array('Wrong', 'Namespace', 'Here'), $namespace->name->parts);
     }
 
@@ -101,7 +101,7 @@ class ClassRenamerVisitorTest extends TestCase
         self::assertNull($visitor->enterNode($class));
         self::assertSame($class, $visitor->leaveNode($class));
 
-        self::assertSame('Baz', $class->name);
+        self::assertSame('Baz', (string)$class->name);
     }
 
     public function testUnwrapsNamespacedClassCorrectly()
@@ -118,7 +118,7 @@ class ClassRenamerVisitorTest extends TestCase
         self::assertSame($class, $visitor->leaveNode($class));
         self::assertSame(array($class), $visitor->leaveNode($namespace));
 
-        self::assertSame('Baz', $class->name);
+        self::assertSame('Baz', (string)$class->name);
     }
 
     public function testWrapsGlobalClassCorrectly()
@@ -149,7 +149,7 @@ class ClassRenamerVisitorTest extends TestCase
         $visitor->leaveNode($class);
         $visitor->leaveNode($namespace);
 
-        self::assertSame('stdClass', $class->name);
+        self::assertSame('stdClass', (string)$class->name);
         self::assertSame(array('Wrong', 'Namespace', 'Here'), $namespace->name->parts);
     }
 }


### PR DESCRIPTION
~~While looking into https://github.com/Ocramius/GeneratedHydrator/issues/79 I came across #14. Main difference with #16 is that this PR keeps support for PHP Parser 2 and 3 while adding support for 4.~~

Drop support for nikic/php-parser 2 and 3, and raise the required version to 4.

Implements / Closes #14
Replaces / Closes #16